### PR TITLE
Clean frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# === INSTALL ===
+
+install:
+	pip install -r requirements.txt
+
+# === RUN ===
+
+run-backend:
+	uvicorn api.fast:app --reload --port 8000
+
+run-frontend:
+	streamlit run frontend/app.py
+
+# === DEV ===
+
+dev:
+	@echo "Launching backend and frontend in parallel..."
+	@echo "Press Ctrl+C to stop."
+	# Requires 'concurrently' tool or use separate terminals manually
+	# See docs or README for manual run
+
+# === HELP ===
+
+help:
+	@echo "Usage:"
+	@echo "  make install         Install all dependencies"
+	@echo "  make run-backend     Run FastAPI backend (http://localhost:8000)"
+	@echo "  make run-frontend    Run Streamlit frontend (http://localhost:8501)"

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,0 +1,55 @@
+import streamlit as st
+from PIL import Image
+import requests
+import os
+
+
+# URL of the backend API (to be connected later)
+API_URL = os.getenv("API_URL", "http://localhost:8000/predict")
+
+st.set_page_config(layout="wide")
+
+# Page title and instructions
+st.title("Art DNA - Painting Style Predictor")
+st.markdown("Upload an image of a painting to predict its art styles.")
+
+# Image uploader
+uploaded_image = st.file_uploader("Upload a painting", type=["jpg", "jpeg", "png"])
+
+# If a file is uploaded, show layout
+if uploaded_image:
+
+    col1, col2 = st.columns([1, 1])
+
+    # Load and display the uploaded image in the left column
+    image = Image.open(uploaded_image)
+    with col1:
+        st.image(image, use_container_width=True)
+
+    # Analyze button in the right column
+    with col2:
+        if st.button("🔍 Analyze Painting", use_container_width=True):
+            with st.spinner("Analyzing..."):
+
+                # Try sending the image to the API
+                try:
+                    response = requests.post(API_URL, files={"image": uploaded_image})
+                    if response.status_code == 200:
+                        prediction = response.json().get("predictions", {})
+                        prediction = {k: round(v * 100) for k, v in prediction.items()}
+                        st.success("✅ Prediction received from API!")
+                    else:
+                        raise ValueError("Invalid response")
+
+                except Exception:
+                    st.warning("⚠️ API not available — showing default prediction.")
+                    prediction = {
+                        "Impressionism": 70,
+                        "Cubism": 20,
+                        "Others": 10
+    }
+
+            # Display prediction results as text
+            st.markdown("##### Predicted Styles")
+            for style, confidence in prediction.items():
+                st.markdown(f"- **{style}**: {confidence}%")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,14 @@
-scikit-learn
+# Backend dependencies
 fastapi
 uvicorn
-python-dotenv
+python-multipart
+
+# Frontend dependencies
 streamlit
+requests
+pillow
+
+# Shared
+python-dotenv
+scikit-learn
+


### PR DESCRIPTION
Added Streamlit app in the frontend/ folder
- Allows users to upload a painting- 
- Sends the image to the FastAPI backend (or shows dummy data if API is offline)
- Displays predicted art styles and percentages

Added a Makefile, run on seperate terminal :
- make install (install requirements)
- make run-backend
- make run-frontend

Updated requirements.txt to sort by section (front-end, back-end, shared)

![output](https://github.com/user-attachments/assets/f8d27e0a-8ace-4c29-849a-be1d75d24a2e)
